### PR TITLE
Circumvent MySQL flaw where two columns with default timestamp aren't…

### DIFF
--- a/src/Model/Activity/Activity.php
+++ b/src/Model/Activity/Activity.php
@@ -58,7 +58,7 @@ class Activity implements \JsonSerializable
     /**
      * Date at which the activity was created.
      *
-     * @Column(type="datetime", columnDefinition="TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+     * @Column(type="datetime", columnDefinition="TIMESTAMP DEFAULT 0")
      * @var \DateTime
      * @SWG\Property()
      */


### PR DESCRIPTION
… allowed.

Exception: 
[Doctrine\DBAL\Driver\PDOException]
  SQLSTATE[HY000]: General error: 1293 Incorrect table definition; there can be only one TIMESTA
  MP column with CURRENT_TIMESTAMP in DEFAULT or ON UPDATE clause