### PR TITLE
Set max-width for images within markdown generated content.

### DIFF
--- a/public/assets/flatly/css/style-screen.css
+++ b/public/assets/flatly/css/style-screen.css
@@ -1154,3 +1154,10 @@ meter[value="4"]::-moz-meter-bar { background: green; }
     padding: 0 .25em;
     margin-top: 1em;
 }
+
+/* Markdown generated content
+-------------------------------------------------- */
+
+.md-generated-content img {
+    max-width: 100%;
+}

--- a/view/flatly/templates/pages/viewer.twig
+++ b/view/flatly/templates/pages/viewer.twig
@@ -29,8 +29,9 @@
                         </span>
                     {% endif %}
                 </h3>
-                {{ activity.elaboration|bb2html|raw }}
-
+                <div class="md-generated-content">
+                    {{ activity.elaboration|bb2html|raw }}
+                </div>
 
                 <h3 class="activity-section">
                     {{ "Planning"|trans }}


### PR DESCRIPTION
Example of the problem:
![problem-md-img](https://cloud.githubusercontent.com/assets/7315457/14754556/644638d2-08dc-11e6-8292-cc90c7a50ea0.png)
